### PR TITLE
Handle datetime strings when fetching market data

### DIFF
--- a/src/pipelines/data_pipeline.py
+++ b/src/pipelines/data_pipeline.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from datetime import datetime, timedelta
+from datetime import timedelta
 from typing import Optional
 
 import pandas as pd
@@ -23,10 +23,16 @@ class MarketDataFetcher:
             self.instrument_tokens = InstrumentTokenManager().get_instrument_tokens()
 
     def fetch(self, instrument: str, from_date: str, to_date: str) -> pd.DataFrame:
+        """Fetch market data between ``from_date`` and ``to_date`` (inclusive).
+
+        The inputs can be simple ``YYYY-MM-DD`` strings or full ISO datetime
+        strings; any time component is ignored so the request still spans whole
+        trading days.
+        """
         instrument_token = get_instrument_token(self.instrument_tokens, instrument)
 
-        start = datetime.strptime(from_date, "%Y-%m-%d")
-        end = datetime.strptime(to_date, "%Y-%m-%d")
+        start = pd.to_datetime(from_date, errors="raise").normalize()
+        end = pd.to_datetime(to_date, errors="raise").normalize()
         if start > end:
             raise ValueError("from_date must be earlier than to_date")
 


### PR DESCRIPTION
## Summary
- allow `MarketDataFetcher` to accept full datetime strings by normalising them to day boundaries
- document the behaviour and clean up imports in the data pipeline module

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68e00056e7848333b4c2d2867876bbe0