### PR TITLE
Ensure inference window respects EMA lookback requirements

### DIFF
--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -9,7 +9,7 @@ data:
   interval: 15minute
   train_from: '2024-09-01 09:15:00'
   train_to: '2025-03-01 15:30:00'
-  inference_window_days: 5
+  inference_window_days: 5  # minimum fetch window; auto-raised to satisfy the longest EMA
   feature_cols:
     - open
     - high


### PR DESCRIPTION
## Summary
- derive the candle interval minutes from the data configuration to compute daily bar capacity
- ensure the inference window backfill covers at least 200 bars (or the configured lookback) before prediction
- document that `inference_window_days` is automatically raised to satisfy the longest EMA requirement

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e007443f408333b616f1a7f592f45b