### PR TITLE
Remove legacy strategy feature dependencies

### DIFF
--- a/configs/config.yaml
+++ b/configs/config.yaml
@@ -5,7 +5,7 @@ project:
 
 data:
   lookback: 60          # number of past days to use as input
-  predict_horizon: 10   # number of days to predict (we will average them)
+  predict_horizon: 10   # number of intervals ahead to forecast the close/return
   interval: 15minute
   train_from: '2024-09-01 09:15:00'
   train_to: '2025-03-01 15:30:00'
@@ -33,7 +33,6 @@ strategy:
   min_buy_rsi: 52.0
   max_sell_rsi: 45.0
   require_ema_alignment: true   # insist on EMA trend confirmation
-  min_volume_ratio: 1.0         # Avg_2_days_Volume / Avg_10_days_Volume must exceed this
 
 kite:
   api_key: "usvvbzqq7736z01b"

--- a/src/predict_live.py
+++ b/src/predict_live.py
@@ -24,8 +24,9 @@ class PredictAgent:
         data_cfg = self.cfg['data']
         kite_cfg = self.cfg['kite']
 
-        self.lookback = data_cfg['lookback']
-        self.feature_engineer = IntradayFeatureEngineer(self.lookback)
+        self.lookback = int(data_cfg['lookback'])
+        self.horizon = int(data_cfg.get('predict_horizon', 1))
+        self.feature_engineer = IntradayFeatureEngineer(self.lookback, self.horizon)
         strategy_cfg = self.cfg.get('strategy', {})
         self.strategy = IntradayStrategy(**strategy_cfg)
 
@@ -98,22 +99,10 @@ class PredictAgent:
             'EMA_200': row['ema200'],
             'EMA_50': row['ema50'],
             'EMA_20': row['ema20'],
-            'ATR': row['atr'],
-            'prev_day_touch_EMA20': bool(row['prev_day_touch_ema20']),
-            'prev_day_touch_EMA50': bool(row['prev_day_touch_ema50']),
-            'prev_day_Close': row['prev_day_close'],
-            'prev_day_Open': row['prev_day_open'],
-            'prev_day_Low': row['prev_day_low'],
-            '5_day_min_of_close': row['min_5_day_close'],
-            'Avg_2_days_Volume': row['avg_2_days_volume'],
-            'Avg_10_days_Volume': row['avg_10_days_volume'],
-            'divergence': row['divergence'],
             'Signal': int(predicted_return > 0),
             'predicted_return': predicted_return,
             'predicted_close': predicted_close,
             'projected_move': predicted_close - row['close'],
-            'stop_loss_buy': row['close'] - row['atr'] * self.strategy.atr_multiple,
-            'stop_loss_sell': row['close'] + row['atr'] * self.strategy.atr_multiple,
             'future_close': row.get('future_close', np.nan),
         }
         return pd.DataFrame([payload])

--- a/src/training_agent.py
+++ b/src/training_agent.py
@@ -26,8 +26,9 @@ class TrainingAgent:
         data_cfg = self.cfg['data']
         kite_cfg = self.cfg['kite']
 
-        self.lookback = data_cfg['lookback']
-        self.feature_engineer = IntradayFeatureEngineer(self.lookback)
+        self.lookback = int(data_cfg['lookback'])
+        self.horizon = int(data_cfg.get('predict_horizon', 1))
+        self.feature_engineer = IntradayFeatureEngineer(self.lookback, self.horizon)
         strategy_cfg = self.cfg.get('strategy', {})
         self.strategy = IntradayStrategy(**strategy_cfg)
 
@@ -154,21 +155,10 @@ class TrainingAgent:
         frame['EMA_200'] = frame['ema200']
         frame['EMA_50'] = frame['ema50']
         frame['EMA_20'] = frame['ema20']
-        frame['ATR'] = frame['atr']
-        frame['prev_day_touch_EMA20'] = frame['prev_day_touch_ema20']
-        frame['prev_day_touch_EMA50'] = frame['prev_day_touch_ema50']
-        frame['prev_day_Close'] = frame['prev_day_close']
-        frame['prev_day_Open'] = frame['prev_day_open']
-        frame['prev_day_Low'] = frame['prev_day_low']
-        frame['5_day_min_of_close'] = frame['min_5_day_close']
-        frame['Avg_2_days_Volume'] = frame['avg_2_days_volume']
-        frame['Avg_10_days_Volume'] = frame['avg_10_days_volume']
         frame['Signal'] = (predicted_returns > 0).astype(int)
         frame['predicted_return'] = predicted_returns
         frame['predicted_close'] = predicted_close
         frame['projected_move'] = frame['predicted_close'] - frame['Close']
-        frame['stop_loss_buy'] = frame['Close'] - frame['ATR'] * self.strategy.atr_multiple
-        frame['stop_loss_sell'] = frame['Close'] + frame['ATR'] * self.strategy.atr_multiple
         return frame
 
     def _calibrate_min_predicted_return(self, frame: pd.DataFrame) -> float:


### PR DESCRIPTION
## Summary
- drop the previous-day and volume aggregation feature engineering so only the core technical indicators remain
- update the feature pipeline, training agent, and live prediction flow to consume the reduced feature set
- simplify the intraday strategy configuration and rules to match the available inputs

## Testing
- PYTHONPATH=src python - <<'PY'
import numpy as np
import pandas as pd
from pipelines.feature_pipeline import IntradayFeatureEngineer

rows = 20
rng = pd.date_range('2024-01-01 09:15:00', periods=rows, freq='15min')
close = np.linspace(100, 105, rows)
open_ = close + 0.1
high = close + 0.5
low = close - 0.5
volume = np.linspace(1000, 1200, rows)

df = pd.DataFrame({
    'date': rng,
    'open': open_,
    'high': high,
    'low': low,
    'close': close,
    'volume': volume,
})

engineer = IntradayFeatureEngineer(lookback=5, horizon=3)
frame = engineer.prepare_training_frame(df)
print(len(frame))
print(frame[['date', 'close', 'future_close', 'target_return']].head())
PY

------
https://chatgpt.com/codex/tasks/task_e_68e01b90bd6c83338f50a2ba25e0196a